### PR TITLE
Issue # SB-15264: exposing basePath in the certificate instead of domain + slug

### DIFF
--- a/all-actors/src/main/java/org/sunbird/CertMapper.java
+++ b/all-actors/src/main/java/org/sunbird/CertMapper.java
@@ -95,7 +95,7 @@ public class CertMapper {
         List<String> validatedPublicKeys = new ArrayList<>();
         publicKeys.forEach((publicKey) -> {
             if (!publicKey.startsWith("http")) {
-                validatedPublicKeys.add(properties.get(JsonKey.DOMAIN_URL).concat("/") + properties.get(JsonKey.SLUG)
+                validatedPublicKeys.add(properties.get(JsonKey.BASE_PATH)
                         .concat("/") + JsonKey.KEYS.concat("/") + publicKey.concat("_publicKey.json"));
             } else {
                 validatedPublicKeys.add(publicKey);

--- a/all-actors/src/main/java/org/sunbird/CertsConstant.java
+++ b/all-actors/src/main/java/org/sunbird/CertsConstant.java
@@ -26,28 +26,40 @@ public class CertsConstant {
     private String CONTAINER_NAME;
     private static final String ENC_SERVICE_URL = getEncServiceUrl();
     private String CLOUD_STORAGE_TYPE;
+    private static String BASE_PATH;
     private static final String SLUG = getSlugFormEnv();
     private static final String DOMAIN_SLUG = DOMAIN_URL + "/" + SLUG;
 
     public String getBADGE_URL(String tag) {
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(DOMAIN_URL + "/" + SLUG);
+        stringBuilder.append(BASE_PATH);
         if (StringUtils.isNotEmpty(tag))
             stringBuilder.append("/" + tag);
         return stringBuilder.append("/" + BADGE_URL).toString();
     }
 
+    public void setBasePath(String basePath) {
+        if (StringUtils.isNotBlank(basePath)) {
+            BASE_PATH = basePath;
+        } else {
+            BASE_PATH = DOMAIN_URL + "/" + SLUG;
+        }
+    }
+
+    public String getBasePath() {
+        return BASE_PATH;
+    }
 
     public String getISSUER_URL() {
-        return DOMAIN_SLUG + "/" + ISSUER_URL;
+        return BASE_PATH + "/" + ISSUER_URL;
     }
 
     public String getCONTEXT() {
-        return String.format("%s/%s/%s", DOMAIN_URL, SLUG, CONTEXT);
+        return String.format("%s/%s", BASE_PATH, CONTEXT);
     }
 
     public String getPUBLIC_KEY_URL(String keyId) {
-        return DOMAIN_SLUG + "/" + JsonKey.KEYS + "/" + keyId + PUBLIC_KEY_URL;
+        return BASE_PATH + "/" + JsonKey.KEYS + "/" + keyId + PUBLIC_KEY_URL;
     }
 
     public String getVERIFICATION_TYPE() {
@@ -117,7 +129,7 @@ public class CertsConstant {
 
 
     public String getSignCreator(String keyId) {
-        return DOMAIN_SLUG + "/" + keyId + PUBLIC_KEY_URL;
+        return BASE_PATH + "/" + keyId + PUBLIC_KEY_URL;
     }
 
     public String getEncryptionServiceUrl() {
@@ -156,7 +168,7 @@ public class CertsConstant {
     }
 
     public String getSignatoryExtensionUrl() {
-        return String.format("%s/%s/%s/%s", DOMAIN_URL, SLUG, SIGNATORY_EXTENSION, "context.json");
+        return String.format("%s/%s/%s", BASE_PATH, SIGNATORY_EXTENSION, "context.json");
     }
 
 

--- a/all-actors/src/main/java/org/sunbird/JsonKey.java
+++ b/all-actors/src/main/java/org/sunbird/JsonKey.java
@@ -111,4 +111,5 @@ public interface JsonKey {
     String HOSTED = "hosted";
     String SIGNED_BADGE = "SignedBadge";
     String EXPIRES = "expires";
+    String BASE_PATH = "basePath";
 }

--- a/all-actors/src/main/java/org/sunbird/cert/actor/CertificateGeneratorActor.java
+++ b/all-actors/src/main/java/org/sunbird/cert/actor/CertificateGeneratorActor.java
@@ -175,6 +175,8 @@ public class CertificateGeneratorActor extends BaseActor {
         String tag = (String) ((Map) request.get(JsonKey.CERTIFICATE)).get(JsonKey.TAG);
         String preview = (String) ((Map<String, Object>) request.getRequest().get(JsonKey.CERTIFICATE)).get(JsonKey.PREVIEW);
         Map<String, Object> keysObject = (Map<String, Object>) ((Map) request.get(JsonKey.CERTIFICATE)).get(JsonKey.KEYS);
+        certVar.setBasePath((String) ((Map<String, Object>) request.getRequest().get(JsonKey.CERTIFICATE))
+                .get(JsonKey.BASE_PATH));
         if (MapUtils.isNotEmpty(keysObject)) {
             String keyId = (String) keysObject.get(JsonKey.ID);
             properties.put(JsonKey.KEY_ID, keyId);
@@ -184,7 +186,6 @@ public class CertificateGeneratorActor extends BaseActor {
         }
         properties.put(JsonKey.TAG, tag);
         properties.put(JsonKey.CONTAINER_NAME, certVar.getCONTAINER_NAME());
-        properties.put(JsonKey.DOMAIN_URL, certVar.getDOMAIN_URL());
         properties.put(JsonKey.BADGE_URL, certVar.getBADGE_URL(tag));
         properties.put(JsonKey.ISSUER_URL, certVar.getISSUER_URL());
         properties.put(JsonKey.CONTEXT, certVar.getCONTEXT());
@@ -196,6 +197,7 @@ public class CertificateGeneratorActor extends BaseActor {
         properties.put(JsonKey.SIGNATORY_EXTENSION, certVar.getSignatoryExtensionUrl());
         properties.put(JsonKey.SLUG, certVar.getSlug());
         properties.put(JsonKey.PREVIEW, certVar.getPreview(preview));
+        properties.put(JsonKey.BASE_PATH, certVar.getBasePath());
 
         logger.info("CertificateGeneratorActor:getProperties:properties got from Constant File ".concat(Collections.singleton(properties.toString()) + ""));
         return properties;

--- a/all-actors/src/main/java/org/sunbird/cert/actor/CertificateVerifierActor.java
+++ b/all-actors/src/main/java/org/sunbird/cert/actor/CertificateVerifierActor.java
@@ -148,7 +148,7 @@ public class CertificateVerifierActor extends BaseActor {
         try {
             String uri = new URL(url).getPath().substring(1);
             String filePath = "conf/";
-            certStore.get(uri.substring(uri.indexOf("/")).substring(1));
+            certStore.get(StringUtils.substringAfter(uri, "/"));
             File file = new File(filePath + getFileName(uri));
             Map<String, Object> certificate = mapper.readValue(file, new TypeReference<Map<String, Object>>() {
             });

--- a/all-actors/src/main/java/org/sunbird/cert/actor/CertificateVerifierActor.java
+++ b/all-actors/src/main/java/org/sunbird/cert/actor/CertificateVerifierActor.java
@@ -146,9 +146,9 @@ public class CertificateVerifierActor extends BaseActor {
         ICertStore certStore = certStoreFactory.getCloudStore(storeConfig);
         certStore.init();
         try {
-            String uri = new URL(url).getPath();
+            String uri = new URL(url).getPath().substring(1);
             String filePath = "conf/";
-            certStore.get(uri.substring(certsConstant.getSlug().length() + 2));
+            certStore.get(uri.substring(uri.indexOf("/")).substring(1));
             File file = new File(filePath + getFileName(uri));
             Map<String, Object> certificate = mapper.readValue(file, new TypeReference<Map<String, Object>>() {
             });

--- a/certgen/certProcessor/src/main/java/org/incredible/CertificateGenerator.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/CertificateGenerator.java
@@ -109,8 +109,7 @@ public class CertificateGenerator {
         QRCodeGenerationModel qrCodeGenerationModel = new QRCodeGenerationModel();
         qrCodeGenerationModel.setText(accessCode);
         qrCodeGenerationModel.setFileName(directory + getUUID(certificateExtension.getId()));
-        qrCodeGenerationModel.setData(properties.get(JsonKey.DOMAIN_URL).concat("/") +
-                properties.get(JsonKey.SLUG).concat("/") + getUUID(certificateExtension.getId()));
+        qrCodeGenerationModel.setData(properties.get(JsonKey.BASE_PATH).concat("/") + getUUID(certificateExtension.getId()));
         QRCodeImageGenerator qrCodeImageGenerator = new QRCodeImageGenerator();
         File qrCode = qrCodeImageGenerator.createQRImages(qrCodeGenerationModel);
         logger.info("Qrcode {} is created for the certificate", qrCode.getName());

--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/CertificateFactory.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/CertificateFactory.java
@@ -36,8 +36,8 @@ public class CertificateFactory {
     public CertificateExtension createCertificate(CertModel certModel, Map<String, String> properties)
             throws InvalidDateFormatException, SignatureException.UnreachableException, IOException, SignatureException.CreationException {
 
-        String domainUrl = getDomainUrl(properties);
-        uuid = domainUrl + "/" + UUID.randomUUID().toString() + ".json";
+        String basePath = getDomainUrl(properties);
+        uuid = basePath + "/" + UUID.randomUUID().toString() + ".json";
         CertificateExtensionBuilder certificateExtensionBuilder = new CertificateExtensionBuilder(properties.get(JsonKey.CONTEXT));
         CompositeIdentityObjectBuilder compositeIdentityObjectBuilder = new CompositeIdentityObjectBuilder(properties.get(JsonKey.CONTEXT));
         BadgeClassBuilder badgeClassBuilder = new BadgeClassBuilder(properties.get(JsonKey.CONTEXT));
@@ -46,7 +46,7 @@ public class CertificateFactory {
         SignatureBuilder signatureBuilder = new SignatureBuilder();
 
         Criteria criteria = new Criteria();
-        criteria.setId(domainUrl);
+        criteria.setId(basePath);
         criteria.setNarrative(certModel.getCertificateDescription());
 
         /**
@@ -170,7 +170,7 @@ public class CertificateFactory {
      */
     private String getDomainUrl(Map<String, String> properties) {
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(properties.get(JsonKey.DOMAIN_URL)).append("/").append(properties.get(JsonKey.SLUG));
+        stringBuilder.append(properties.get(JsonKey.BASE_PATH));
         if (StringUtils.isNotEmpty(properties.get(JsonKey.TAG))) {
             stringBuilder.append("/" + properties.get(JsonKey.TAG));
         }

--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/JsonKey.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/JsonKey.java
@@ -41,7 +41,7 @@ public interface JsonKey {
     String ENC_SERVICE_URL = "sunbird_cert_enc_service_url";
     String SIGN = "sign";
     String VERIFY = "verify";
-
+    String BASE_PATH = "basePath";
 
 
 }

--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/store/CertStoreFactory.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/store/CertStoreFactory.java
@@ -9,6 +9,8 @@ import org.apache.log4j.Logger;
 import org.incredible.certProcessor.JsonKey;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -64,12 +66,18 @@ public class CertStoreFactory {
      */
     public ICertStore getCertStore(StoreConfig storeConfig, Boolean preview) {
         ICertStore store = null;
-        if (preview) {
-            store = new LocalStore(properties.get(JsonKey.DOMAIN_URL));
-        } else if (storeConfig.isCloudStore()) {
-            store = getCloudStore(storeConfig);
-        } else {
-            store = new LocalStore(properties.get(JsonKey.DOMAIN_URL));
+        try {
+            String path = new URL(properties.get(JsonKey.BASE_PATH)).getPath();
+            if (preview) {
+                StringUtils.remove(properties.get(JsonKey.BASE_PATH), path);
+                store = new LocalStore(StringUtils.remove(properties.get(JsonKey.BASE_PATH), path));
+            } else if (storeConfig.isCloudStore()) {
+                store = getCloudStore(storeConfig);
+            } else {
+                store = new LocalStore(StringUtils.remove(properties.get(JsonKey.BASE_PATH), path));
+            }
+        } catch (MalformedURLException e) {
+
         }
         return store;
     }

--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/store/CertStoreFactory.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/store/CertStoreFactory.java
@@ -67,14 +67,13 @@ public class CertStoreFactory {
     public ICertStore getCertStore(StoreConfig storeConfig, Boolean preview) {
         ICertStore store = null;
         try {
-            String path = new URL(properties.get(JsonKey.BASE_PATH)).getPath();
+            String domainUrl = StringUtils.remove(properties.get(JsonKey.BASE_PATH), new URL(properties.get(JsonKey.BASE_PATH)).getPath());
             if (preview) {
-                StringUtils.remove(properties.get(JsonKey.BASE_PATH), path);
-                store = new LocalStore(StringUtils.remove(properties.get(JsonKey.BASE_PATH), path));
+                store = new LocalStore(domainUrl);
             } else if (storeConfig.isCloudStore()) {
                 store = getCloudStore(storeConfig);
             } else {
-                store = new LocalStore(StringUtils.remove(properties.get(JsonKey.BASE_PATH), path));
+                store = new LocalStore(domainUrl);
             }
         } catch (MalformedURLException e) {
 

--- a/service/app/controllers/certs/CertValidator.java
+++ b/service/app/controllers/certs/CertValidator.java
@@ -3,6 +3,7 @@ package controllers.certs;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.validator.UrlValidator;
 import org.sunbird.BaseException;
 import org.sunbird.message.IResponseMessage;
 import org.sunbird.message.ResponseCode;
@@ -37,7 +38,11 @@ public class CertValidator {
         validateCertData((List<Map<String, Object>>) certReq.get(JsonKey.DATA));
         validateCertIssuer((Map<String, Object>) certReq.get(JsonKey.ISSUER));
         validateCertSignatoryList((List<Map<String, Object>>) certReq.get(JsonKey.SIGNATORY_LIST));
-        if(certReq.containsKey(JsonKey.STORE)) {
+        String basePath = (String) certReq.get(JsonKey.BASE_PATH);
+        if(StringUtils.isNotBlank(basePath))    {
+            validateBasePath(basePath);
+        }
+        if (certReq.containsKey(JsonKey.STORE)) {
             validateStore((Map<String, Object>) certReq.get(JsonKey.STORE));
         }
         if (certReq.containsKey(JsonKey.KEYS)) {
@@ -152,6 +157,17 @@ public class CertValidator {
         if(!StorageType.get().contains(data.get(JsonKey.TYPE)))  {
             throw new BaseException("INVALID_PARAM_VALUE",
                     MessageFormat.format(IResponseMessage.INVALID_PARAM_VALUE, data.get(JsonKey.TYPE), parentKey + "." + JsonKey.TYPE),
+                    ResponseCode.CLIENT_ERROR.getCode());
+        }
+    }
+
+    private static void validateBasePath(String basePath) throws BaseException {
+        UrlValidator urlValidator = new UrlValidator();
+        boolean isValid = urlValidator.isValid(basePath);
+        if (!isValid) {
+            throw new BaseException("INVALID_PARAM_VALUE",
+                    MessageFormat.format(IResponseMessage.INVALID_PARAM_VALUE, basePath, JsonKey.CERTIFICATE
+                            + "." + JsonKey.BASE_PATH),
                     ResponseCode.CLIENT_ERROR.getCode());
         }
     }


### PR DESCRIPTION
Idea is that domain and slug will be defaulted from the env. If the payload provides a 'basePath', then it will be used.