### PR TITLE
Improve cert-performance : removed reflection and velocity

### DIFF
--- a/all-actors/pom.xml
+++ b/all-actors/pom.xml
@@ -29,6 +29,11 @@
             <version>2.6.0-M5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.4</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/all-actors/pom.xml
+++ b/all-actors/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.4</version>
+            <version>1.8</version>
         </dependency>
     </dependencies>
     <build>

--- a/all-actors/src/main/java/org/sunbird/SvgGenerator.java
+++ b/all-actors/src/main/java/org/sunbird/SvgGenerator.java
@@ -1,13 +1,11 @@
 package org.sunbird;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.velocity.VelocityContext;
+import org.apache.commons.text.StringSubstitutor;
 import org.apache.velocity.app.Velocity;
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.incredible.certProcessor.store.LocalStore;
-import org.incredible.certProcessor.views.HTMLTemplateValidator;
 import org.incredible.certProcessor.views.HTMLVarResolver;
 import org.incredible.pojos.CertificateExtension;
 import org.slf4j.Logger;
@@ -18,17 +16,11 @@ import org.sunbird.message.ResponseCode;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -38,12 +30,10 @@ public class SvgGenerator {
     private String svgTemplate;
     private String directory;
     private static Map<String, String> encoderMap = new HashMap<>();
+    private static Map<String, String> cachedSvgTemplates = new HashMap<>();
 
 
     static {
-        Velocity.setProperty(RuntimeConstants.RESOURCE_LOADER, "classpath");
-        Velocity.setProperty("classpath.resource.loader.class", ClasspathResourceLoader.class.getName());
-        Velocity.init();
         encoderMap.put("<", "%3C");
         encoderMap.put(">", "%3E");
         encoderMap.put("#", "%23");
@@ -61,59 +51,42 @@ public class SvgGenerator {
         String svgContent;
         File file = new File(directory + svgFileName);
         if (!file.exists()) {
+            logger.info("{} file does not exits , downloading", svgFileName);
             download(svgFileName);
-        }
-        svgContent = readSvgContent(file.getAbsolutePath());
-        String encodedSvg = null;
-        try {
-            encodedSvg = "data:image/svg+xml," + replaceTemplateVars(encodeData(svgContent), certificateExtension, encodedQrCode);
+            svgContent = readSvgContent(file.getAbsolutePath());
+            String encodedSvg = "data:image/svg+xml," + encodeData(svgContent);
             encodedSvg = encodedSvg.replaceAll("\n", "").replaceAll("\t", "");
-        } catch (IOException e) {
-            logger.info("SvgGenerator:generate exception while encoding svgContent {}", e.getMessage());
+            cachedSvgTemplates.put(this.svgTemplate, encodedSvg);
         }
+        logger.info("svg template is cache {}", cachedSvgTemplates.containsKey(this.svgTemplate));
+        String svgData = replaceTemplateVars(cachedSvgTemplates.get(this.svgTemplate), certificateExtension, encodedQrCode);
         logger.info("svg template string creation completed");
-        return encodedSvg;
+        return svgData;
     }
 
 
-    private String replaceTemplateVars(String svgContent, CertificateExtension certificateExtension, String encodeQrCode) throws IOException {
+    private String replaceTemplateVars(String svgContent, CertificateExtension certificateExtension, String encodeQrCode) {
         HTMLVarResolver htmlVarResolver = new HTMLVarResolver(certificateExtension);
-        VelocityContext context = new VelocityContext();
-        Set<String> htmlReferenceVariable = HTMLTemplateValidator.storeAllHTMLTemplateVariables(svgContent);
-        for (String var : htmlReferenceVariable) {
-            String macro = var.substring(1);
-            try {
-                Method method = htmlVarResolver.getClass().getMethod("get" + StringUtils.capitalize(macro));
-                method.setAccessible(true);
-                String data = URLEncoder.encode((String) method.invoke(htmlVarResolver), "UTF-8");
-                // URLEncoder.encode replace space with "+", but it should %20
-                context.put(macro, data.replace("+", "%20"));
-            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | UnsupportedEncodingException e) {
-                logger.info("exception while replacing TemplateVars of svg {}", e.getMessage());
-            }
-        }
-        context.put("qrCodeImage", "data:image/png;base64," + encodeQrCode);
-        StringWriter stringWriter = new StringWriter();
-        Velocity.evaluate(context, stringWriter, "velocity", svgContent);
-        stringWriter.flush();
-        stringWriter.close();
-        return stringWriter.toString();
+        Map<String, String> certData = htmlVarResolver.getCertMetaData();
+        certData.put("qrCodeImage", "data:image/png;base64," + encodeQrCode);
+        StringSubstitutor sub = new StringSubstitutor(certData);
+        String resolvedString = sub.replace(svgContent);
+        logger.info("replacing temp vars completed");
+        return resolvedString;
     }
 
     private String encodeData(String data) {
         StringBuffer stringBuffer = new StringBuffer();
-        if (StringUtils.isNotEmpty(data)) {
-            Pattern pattern = Pattern.compile("[<>#%\"]");
-            Matcher matcher = pattern.matcher(data);
-            while (matcher.find()) {
-                matcher.appendReplacement(stringBuffer, encoderMap.get(matcher.group()));
-            }
-            matcher.appendTail(stringBuffer);
+        Pattern pattern = Pattern.compile("[<>#%\"]");
+        Matcher matcher = pattern.matcher(data);
+        while (matcher.find()) {
+            matcher.appendReplacement(stringBuffer, encoderMap.get(matcher.group()));
         }
+        matcher.appendTail(stringBuffer);
         return stringBuffer.toString();
     }
 
-    private String readSvgContent(String path)  throws BaseException {
+    private String readSvgContent(String path) throws BaseException {
         FileInputStream fis;
         String svgContent = null;
         try {

--- a/all-actors/src/main/java/org/sunbird/SvgGenerator.java
+++ b/all-actors/src/main/java/org/sunbird/SvgGenerator.java
@@ -2,9 +2,6 @@ package org.sunbird;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.text.StringSubstitutor;
-import org.apache.velocity.app.Velocity;
-import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.incredible.certProcessor.store.LocalStore;
 import org.incredible.certProcessor.views.HTMLVarResolver;
 import org.incredible.pojos.CertificateExtension;
@@ -58,7 +55,7 @@ public class SvgGenerator {
             encodedSvg = encodedSvg.replaceAll("\n", "").replaceAll("\t", "");
             cachedSvgTemplates.put(this.svgTemplate, encodedSvg);
         }
-        logger.info("svg template is cache {}", cachedSvgTemplates.containsKey(this.svgTemplate));
+        logger.info("svg template is cached {}", cachedSvgTemplates.containsKey(this.svgTemplate));
         String svgData = replaceTemplateVars(cachedSvgTemplates.get(this.svgTemplate), certificateExtension, encodedQrCode);
         logger.info("svg template string creation completed");
         return svgData;

--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/JsonKey.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/JsonKey.java
@@ -118,4 +118,13 @@ public interface JsonKey {
     String REQ_ID = "reqId";
     String REQUEST_MESSAGE_ID = "msgId";
     String X_REQUEST_ID = "X-Request-ID";
+    String CERT_NAME = "certificateName";
+    String CERTIFICATE_DESCIPTION = "certificateDescription";
+    String SIGNATORY_0_IMAGE = "signatory0Image";
+    String SIGNATORY_0_DESIGNATION = "signatory0Designation";
+    String SIGNATORY_1_IMAGE = "signatory1Image";
+    String SIGNATORY_1_DESIGNATION = "signatory1Designation";
+    String QRCODE_IMAGE = "qrCodeImage";
+    String EXPIRY_DATE = "expiryDate";
+    String ISSUER_NAME = "issuerName";
 }

--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/views/HTMLVarResolver.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/views/HTMLVarResolver.java
@@ -2,10 +2,15 @@ package org.incredible.certProcessor.views;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
+import org.incredible.certProcessor.JsonKey;
 import org.incredible.pojos.CertificateExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -17,6 +22,8 @@ import java.util.Map;
 public class HTMLVarResolver {
 
     private CertificateExtension certificateExtension;
+
+    private static Logger logger = LoggerFactory.getLogger(HTMLVarResolver.class);
 
     public HTMLVarResolver(CertificateExtension certificateExtension) {
         this.certificateExtension = certificateExtension;
@@ -109,21 +116,35 @@ public class HTMLVarResolver {
         return certificateExtension.getExpires();
     }
 
+    public String getIssuerName() {
+        return certificateExtension.getBadge().getIssuer().getName();
+    }
+
+
     public Map<String, String> getCertMetaData() {
         Map<String, String> metaData = new HashMap<>();
-        metaData.put("certificateName", getCertificateName());
-        metaData.put("certificateDescription",getCertificateDescription());
-        metaData.put("courseName", getCourseName());
-        metaData.put("issuedDate", getIssuedDate());
-        metaData.put("recipientId", getRecipientId());
-        metaData.put("recipientName", getRecipientName());
-        metaData.put("signatory0Image", getSignatory0Image());
-        metaData.put("signatory0Designation", getSignatory0Designation());
-        metaData.put("signatory1Image", getSignatory1Image());
-        metaData.put("signatory1Designation", getSignatory1Designation());
-        metaData.put("qrCodeImage", getQrCodeImage());
-        metaData.put("expiryDate", getExpiryDate());
+        try {
+            metaData.put(JsonKey.CERT_NAME, urlEncode(getCertificateName()));
+            metaData.put(JsonKey.CERTIFICATE_DESCIPTION,urlEncode(getCertificateDescription()));
+            metaData.put(JsonKey.COURSE_NAME, urlEncode(getCourseName()));
+            metaData.put(JsonKey.ISSUE_DATE, urlEncode(getIssuedDate()));
+            metaData.put(JsonKey.RECIPIENT_ID, urlEncode(getRecipientId()));
+            metaData.put(JsonKey.RECIPIENT_NAME, urlEncode(getRecipientName()));
+            metaData.put(JsonKey.SIGNATORY_0_IMAGE, urlEncode(getSignatory0Image()));
+            metaData.put(JsonKey.SIGNATORY_0_DESIGNATION, urlEncode(getSignatory0Designation()));
+            metaData.put(JsonKey.SIGNATORY_1_IMAGE, urlEncode(getSignatory1Image()));
+            metaData.put(JsonKey.SIGNATORY_1_DESIGNATION, urlEncode(getSignatory1Designation()));
+            metaData.put(JsonKey.EXPIRY_DATE, urlEncode(getExpiryDate()));
+            metaData.put(JsonKey.ISSUER_NAME, urlEncode(getIssuerName()));
+        } catch (UnsupportedEncodingException e) {
+            logger.info("getCertMetaData: exception occurred while url encoding {}", e.getMessage());
+        }
         return metaData;
+    }
+
+    private String urlEncode(String data) throws UnsupportedEncodingException {
+        // URLEncoder.encode replace space with "+", but it should %20
+        return StringUtils.isNotEmpty(data) ? URLEncoder.encode(data, "UTF-8").replace("+", "%20") : data;
     }
 
 }

--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/views/HTMLVarResolver.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/views/HTMLVarResolver.java
@@ -10,7 +10,9 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 public class HTMLVarResolver {
 
@@ -105,6 +107,23 @@ public class HTMLVarResolver {
 
     public String getExpiryDate() {
         return certificateExtension.getExpires();
+    }
+
+    public Map<String, String> getCertMetaData() {
+        Map<String, String> metaData = new HashMap<>();
+        metaData.put("certificateName", getCertificateName());
+        metaData.put("certificateDescription",getCertificateDescription());
+        metaData.put("courseName", getCourseName());
+        metaData.put("issuedDate", getIssuedDate());
+        metaData.put("recipientId", getRecipientId());
+        metaData.put("recipientName", getRecipientName());
+        metaData.put("signatory0Image", getSignatory0Image());
+        metaData.put("signatory0Designation", getSignatory0Designation());
+        metaData.put("signatory1Image", getSignatory1Image());
+        metaData.put("signatory1Designation", getSignatory1Designation());
+        metaData.put("qrCodeImage", getQrCodeImage());
+        metaData.put("expiryDate", getExpiryDate());
+        return metaData;
     }
 
 }

--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/views/HTMLVars.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/views/HTMLVars.java
@@ -33,6 +33,7 @@ public class HTMLVars {
         //others
         $courseName,
         $qrCodeImage,
+        $issuerName
     }
 }
 


### PR DESCRIPTION
Before we had chosen reflection methods given it was okay to have a slow process and we didn’t want to refer template variables explicitly.  Reflection calls are slower than direct calls. We can see a great improvement in reflection API performance with every JVM release, JIT compiler’s optimization algorithms are getting better, but reflective method invocations are still about three times slower than direct ones.

Using velocity: It's not good to use a whole library for a simple task like this. Velocity has a lot of other features, and I believe that's not suitable for a simple task like this(string replacement)

**The template vars format is changed to ${varName} (StringSubstitutor by default supports this format}**

Tested after these changes with no of threads 1 and loop count 100, avg ~ **130ms** 

<img width="825" alt="Screenshot 2020-08-25 at 3 20 01 PM" src="https://user-images.githubusercontent.com/42641684/91160085-9aab3700-e6e6-11ea-9306-4d8d89b99522.png">

**References**
1.  [https://dzone.com/articles/think-twice-before-using-reflection](url) 
2. [https://stackoverflow.com/questions/3655424/string-replacement-in-java-similar-to-a-velocity-template](url) 
