### PR TITLE
SB-20393: set badgeName as courseName

### DIFF
--- a/certgen/certProcessor/src/main/java/org/incredible/certProcessor/CertificateFactory.java
+++ b/certgen/certProcessor/src/main/java/org/incredible/certProcessor/CertificateFactory.java
@@ -60,11 +60,18 @@ public class CertificateFactory {
         /**
          * badge class object
          * **/
-
-        badgeClassBuilder.setName(certModel.getCertificateName()).setDescription(certModel.getCertificateDescription())
+        badgeClassBuilder.setDescription(certModel.getCertificateDescription())
                 .setId(properties.get(JsonKey.BADGE_URL)).setCriteria(certModel.getCriteria())
                 .setImage(certModel.getCertificateLogo()).
                 setIssuer(issuerBuilder.build());
+        //TODO for now badge name is set as course name, it should be certificate name
+        //after certificate QR validation the portal uses badge name to display the course name,but course name is in the training evidence(introduced in release-1.5.0)
+        //in evidence we are setting training name as courseName
+        if(StringUtils.isNotEmpty(certModel.getCourseName())){
+            badgeClassBuilder.setName(certModel.getCourseName());
+        } else {
+            badgeClassBuilder.setName(certModel.getCertificateName());
+        }
 
         /**
          * Training evidence


### PR DESCRIPTION
Issue: Course name displayed is template name instead of course name upon cert QR scan

Set badge name as course name, but courseName is already set in Training Evidence (introduced in release-1.5.0) 
The portal always uses `badge.name` to populate the course name upon cert QR validation. 